### PR TITLE
fix(http): skip empty token auth

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -36,9 +36,11 @@ export function createHttpClient(config: HttpClientConfig) {
       'User-Agent': userAgent,
     },
     onRequest({ request }) {
-      // Add authentication header
-      const authValue = tokenPrefix ? `${tokenPrefix}${token}` : token;
-      request.headers.set(tokenHeader, authValue);
+      // Skip auth header for unauthenticated requests (empty token is intentional)
+      if (token) {
+        const authValue = tokenPrefix ? `${tokenPrefix}${token}` : token;
+        request.headers.set(tokenHeader, authValue);
+      }
     },
     onResponseError({ response }) {
       // Warn on low rate limit

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -119,6 +119,20 @@ describe('createHttpClient', () => {
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
+
+  it('skips auth header when token is empty', () => {
+    createHttpClient({
+      baseURL: 'https://api.github.com',
+      token: '',
+    });
+
+    const headers = new Map<string, string>();
+    mockCreateConfigs[0].onRequest({
+      request: { headers: { set: (k: string, v: string) => headers.set(k, v) } },
+    });
+
+    expect(headers.size).toBe(0);
+  });
 });
 
 describe('rawFetch', () => {


### PR DESCRIPTION
The `onRequest` interceptor in `createHttpClient` was unconditionally setting the auth header, even when the token was an empty string. That means intentionally unauthenticated requests got headers like `Authorization: token ` (trailing space, no value) or an empty `Private-Token`. Depending on the server, that's either ignored or rejected as a bad credential.

- Guard the header write with `if (token)` so empty strings skip it entirely
- Added a test that verifies no header is set with an empty token

Closes #1