### PR TITLE
fix(auth): stop fallback chain on empty-string env token

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -36,19 +36,19 @@ export function resolveToken(
 
   // 2. Environment variables
   const envToken = resolveFromEnv(platform);
-  if (envToken) {
+  if (envToken !== null) {
     return { token: envToken, source: "env" };
   }
 
   // 3. CLI tools
   const cliToken = resolveFromCli(platform, hostname);
-  if (cliToken) {
+  if (cliToken !== null) {
     return { token: cliToken, source: "cli" };
   }
 
   // 4. Config files (fallback if CLI not installed but config exists)
   const configToken = resolveFromConfig(platform, hostname);
-  if (configToken) {
+  if (configToken !== null) {
     return { token: configToken, source: "config" };
   }
 
@@ -85,7 +85,7 @@ const ENV_MAP: Record<Platform, string[]> = {
 function resolveFromEnv(platform: Platform): string | null {
   for (const key of ENV_MAP[platform]) {
     const val = process.env[key];
-    if (val) return val;
+    if (val !== undefined) return val;
   }
   return null;
 }

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -94,6 +94,13 @@ describe("resolveToken", () => {
       const result = resolveToken("gitea");
       expect(result).toEqual({ token: "gitea-abc", source: "env" });
     });
+
+    it("stops the chain when env var is empty string", () => {
+      process.env.GH_TOKEN = "";
+      const result = resolveToken("github");
+      expect(result).toEqual({ token: "", source: "env" });
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    });
   });
 
   // --- CLI tools ---


### PR DESCRIPTION
`resolveFromEnv` used a falsy check (`if (val)`) that treated `GITHUB_TOKEN=""` as unset, falling through to CLI and config detection. Same issue in `resolveToken` where `if (envToken)` / `if (cliToken)` / `if (configToken)` skipped empty-string results.

The explicit token path already handled this correctly with `!== undefined`. Now env detection uses `!== undefined` too, and the chain checks use `!== null` so an empty string from any source stops the chain.

Closes #23