### PR TITLE
chore: add .js extensions to relative imports in gitea provider

### DIFF
--- a/src/providers/gitea.ts
+++ b/src/providers/gitea.ts
@@ -6,11 +6,11 @@
  * - Some fields may be null where GitHub returns empty strings
  */
 
-import { createHttpClient, rawFetch } from "../http";
-import { cachedFetch } from "../cache";
-import { parseLinkHeader } from "../pagination";
-import { normalizeError } from "../errors";
-import { normalizeApiBaseURL } from "./base-url";
+import { createHttpClient, rawFetch } from "../http.js";
+import { cachedFetch } from "../cache.js";
+import { parseLinkHeader } from "../pagination.js";
+import { normalizeError } from "../errors.js";
+import { normalizeApiBaseURL } from "./base-url.js";
 import type {
   Provider,
   ProviderConfig,
@@ -25,7 +25,7 @@ import type {
   Owner,
   PageResult,
   ListOptions,
-} from "../types";
+} from "../types.js";
 
 // -- Raw Gitea API response types --
 


### PR DESCRIPTION
The Gitea provider was the only file in `src/` without `.js` extensions on relative imports. Every other provider and module already uses them consistently.

Closes #24