### PR TITLE
fix(cache): replace unsafe type casts with proper types

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -20,7 +20,7 @@ export interface CacheOptions {
  */
 export interface CachedFetchOptions {
   method?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**
@@ -135,7 +135,7 @@ function compareQueryEntries(
  * @param options Request options
  * @returns Cached or fresh response
  */
-export async function cachedFetch<T = any>(
+export async function cachedFetch<T>(
   client: $Fetch,
   url: string,
   options?: CachedFetchOptions,
@@ -159,8 +159,8 @@ export async function cachedFetch<T = any>(
   // Cache miss: fetch from client
   const result = options ? await client<T>(url, options) : await client<T>(url);
 
-  // Store in cache (cast to StorageValue)
-  await storage.setItem(cacheKey, result as any);
+  // Store in cache
+  await storage.setItem(cacheKey, result as Record<string, unknown>);
 
   return result;
 }


### PR DESCRIPTION
Three type safety issues in the cache module:

- `cachedFetch<T = any>` defaulted its generic to `any`, masking type errors at call sites that forgot to specify `T`. Removed the default so callers must be explicit.
- `storage.setItem(cacheKey, result as any)` cast to `any` to satisfy unstorage's `StorageValue` type. API responses are always objects, so `Record<string, unknown>` is accurate and keeps the type checker engaged.
- `CachedFetchOptions` index signature used `[key: string]: any`. Changed to `unknown` since the values flow into ofetch which handles its own typing.